### PR TITLE
nvim: add better LSP support for Rust

### DIFF
--- a/nvim/lsp.vim
+++ b/nvim/lsp.vim
@@ -260,6 +260,7 @@ use {
 	end
 }
 use 'hrsh7th/cmp-nvim-lsp'
+use 'simrat39/rust-tools.nvim'
 --use 'hrsh7th/vim-vsnip'
 use {
 	'L3MON4D3/LuaSnip',
@@ -273,7 +274,6 @@ use {
 		local cmp = require('cmp')
 		local lspconfig = require('lspconfig')
 		lsps = {
-			'rust_analyzer',
 			'vimls',
 			{
 				'ccls',
@@ -290,7 +290,7 @@ use {
 			},
 			preselect = cmp.PreselectMode.Item,
 			mapping = {
-				['<C-Space'] = cmp.mapping.complete(),
+				['<C-Space>'] = cmp.mapping.complete(),
 				['<Tab>'] = cmp.mapping.select_next_item(),
 				['<S-Tab>'] = cmp.mapping.select_prev_item(),
 				['<CR>'] = cmp.mapping.confirm({ select = false }),
@@ -305,6 +305,14 @@ use {
 
 		-- We really, really dislike snippets.
 		cap.textDocument.completion.completionItem.snippetSupport = false
+
+		-- rust-tools wants to setup the LSP itself, so it needs to be configured specially
+		require('rust-tools').setup({
+			server = {
+				on_attach = lsp_on_attach,
+				capabilities = cap,
+			}
+		})
 
 		for i, lsp in ipairs(lsps) do
 			local lsp_name = ''


### PR DESCRIPTION
This fixes one of the completion mappings and also switches to using [rust-tools](https://github.com/simrat39/rust-tools.nvim) to setup the Rust LSP, which adds back support for type hints.

It's debatable whether this is what you want, but since it's already done, if you want it here's the code.