### PR TITLE
Add bat to the default programs

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -102,5 +102,6 @@ in {
 		any-nix-shell
 		qyriad.niz
 		qyriad.pzl
+		bat
 	];
 }


### PR DESCRIPTION
Bat is extremely useful to have generically as a generalized cat replacement