### PR TITLE
Enable Avahi

### DIFF
--- a/nixos/linux.nix
+++ b/nixos/linux.nix
@@ -67,6 +67,20 @@ in
 
 	services.openssh.enable = true;
 
+	# Avahi is on most systems by default but not NixOS, it's quite useful to have mDNS support.
+	services.avahi = {
+		enable = true;
+
+		# Enable support for resolving names from other systems over mDNS.
+		nssmdns4 = true;
+
+		# Enable support for other systems resolving us via mDNS.
+		publish = {
+			enable = true;
+			addresses = true;
+		};
+	};
+
 	# Our normal user.
 	users.users.qyriad = {
 		isNormalUser = true;


### PR DESCRIPTION
Avahi allows mDNS resolution and publishing and is supported by default on most systems, enable it here as it's quite useful for quickly grabbing local machine IPs