### PR TITLE
Support `.` as a flake reference

### DIFF
--- a/xonsh/rc.xsh
+++ b/xonsh/rc.xsh
@@ -494,7 +494,7 @@ aliases["pl"] = _per_line
 # The first parentheses are a non-capturing group that matches whitespace or the start of the string.
 # The second parenthese are the group we're interested in.
 # The third is a lookahead assertion (to not consume) for whitespace or the end of the string.
-UNQUOTED_INSTALLABLE_PATTERN = re.compile(r"(?:\s|^)+(\w+#\w+)(?=\s|$)+")
+UNQUOTED_INSTALLABLE_PATTERN = re.compile(r"(?:\s|^)+((?:\w+|[.])#\w+)(?=\s|$)+")
 @events.on_transform_command
 def unfuck_nix_installabes(cmd: str):
 	if installables := UNQUOTED_INSTALLABLE_PATTERN.findall(cmd):


### PR DESCRIPTION
This extends the logic to autoquote flake references to support not just alphabetical characters but additionally a `.` to reference the current directory.

Note that there's a bit of weirdness I haven't fully investigated regarding if you supply invalid patterns without quoting.

Specifically the following cases cause supremely odd behavior

```python
irides@Mira ~/code/nix-doc (main) @ showcmd .addd#helloo
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'showcmd' is not defined
```

```python
irides@Mira ~/code/nix-doc (main) @ ![showcmd .addd#helloo]
...................................
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/xonsh/0.14.3/libexec/lib/python3.11/site-packages/xonsh/ptk_shell/shell.py", line 384, in _push
    code = self.execer.compile(
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/xonsh/0.14.3/libexec/lib/python3.11/site-packages/xonsh/execer.py", line 130, in compile
    tree = self.parse(input, ctx, mode=mode, filename=filename, transform=transform)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/xonsh/0.14.3/libexec/lib/python3.11/site-packages/xonsh/execer.py", line 86, in parse
    tree, input = self._parse_ctx_free(input, mode=mode, filename=filename)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/xonsh/0.14.3/libexec/lib/python3.11/site-packages/xonsh/execer.py", line 345, in _parse_ctx_free
    return _try_parse(input, greedy=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/xonsh/0.14.3/libexec/lib/python3.11/site-packages/xonsh/execer.py", line 253, in _try_parse
    raise original_error from None

... snip ...

  File "/opt/homebrew/Cellar/xonsh/0.14.3/libexec/lib/python3.11/site-packages/xonsh/parsers/base.py", line 220, in raise_parse_error
    raise err
SyntaxError: None: no further code
```

For normal, non-antagonistic usage this should be fine though