### PR TITLE
don't apply the overlays twice to the pkgs import in the repl

### DIFF
--- a/nix/repl-overlay.nix
+++ b/nix/repl-overlay.nix
@@ -47,7 +47,7 @@ self = rec {
 	# Instantiated forms of those flakes.
 	pkgs = importQuiet nixpkgs {
 		system = info.currentSystem;
-		overlays = attrValues qyriad.overlays;
+		overlays = [ qyriad.overlays.default ];
 		inherit config;
 	};
 	nixosLib = import (nixpkgs + "/nixos/lib") { inherit (pkgs) lib; featureFlags.minimalModules = true; };


### PR DESCRIPTION
This causes some changes to get duplicated and is generally not a desirable idea. Notably it causes `pkgs.kdePackages.systemsettings` to fail to build because the duplicated patch fails to apply